### PR TITLE
Locate all files in the project root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           git pull
           git checkout gh-pages
-          git add -f public/
+          export dir=$(mktemp -d)
+          mv public $dir/
+          rm -rf *
+          mv $dir/public/* .
           git commit -m 'Deploy the website'
           git push


### PR DESCRIPTION
GitHub Actions does not support specifying the GitHub Pages directory except `/` and `docs/`. `docs/` is not a good name because what I am publishing is not a document. Thus, I place all files in the `public/` directory to the project root.
