### PR TITLE
Remove the `--release` flag

### DIFF
--- a/.github/workflows/install_zola/action.yml
+++ b/.github/workflows/install_zola/action.yml
@@ -13,6 +13,6 @@ runs:
       shell: bash
 
     - name: Build a Zola executable
-      run: cargo install --release --path . --features search/indexing-ja
+      run: cargo install --path . --features search/indexing-ja
       shell: bash
       working-directory: zola


### PR DESCRIPTION
It seems that the default build profile is release. See https://doc.rust-lang.org/cargo/commands/cargo-install.html.
