### PR TITLE
Do not use `find` with the `-exec` option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,9 +110,7 @@ jobs:
         run: sudo apt install zsh
 
       - name: Run test scripts
-        shell: bash -e {0}
-        # `xargs` never fails unless a program finishes with an exit code 255. See `man xargs`.
-        run: find content/blog/* -type d -exec bash -c 'cd "$0" && ./test_script.sh || exit 255' {} \;
+        run: scripts/run_test_scripts.sh
 
   deploy:
     runs-on: ubuntu-latest

--- a/scripts/run_test_scripts.sh
+++ b/scripts/run_test_scripts.sh
@@ -1,0 +1,9 @@
+#!/bin/zsh -xe
+
+# Do not use `find` with the `-exec` option because it will not fail even if a
+# command fails. See
+# https://apple.stackexchange.com/questions/49042/how-do-i-make-find-fail-if-exec-fails.
+for dir in content/blog/*(/)
+do
+    (cd $dir && ./test_script.sh)
+done

--- a/scripts/run_test_scripts.sh
+++ b/scripts/run_test_scripts.sh
@@ -5,5 +5,7 @@
 # https://apple.stackexchange.com/questions/49042/how-do-i-make-find-fail-if-exec-fails.
 for dir in content/blog/*(/)
 do
+    # The commands are enclosed in parentheses to prevent `cd` from affecting
+    # other successive test scripts.
     (cd $dir && ./test_script.sh)
 done

--- a/scripts/run_test_scripts.sh
+++ b/scripts/run_test_scripts.sh
@@ -3,6 +3,9 @@
 # Do not use `find` with the `-exec` option because it will not fail even if a
 # command fails. See
 # https://apple.stackexchange.com/questions/49042/how-do-i-make-find-fail-if-exec-fails.
+#
+# The last `(/)` limits a grob to list only directories. See
+# https://qiita.com/termoshtt/items/a99559dca654ff016b90.
 for dir in content/blog/*(/)
 do
     # The commands are enclosed in parentheses to prevent `cd` from affecting


### PR DESCRIPTION
It will not fail even if a command fails.
