### PR TITLE
Do not check the format of SASS files with `stylelint`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,6 @@
+# TODO: Check the CSS format. `stylelint` is not usable as `postcss-sass` is
+# not maintained anymore.
+# See https://github.com/AleshaOleg/postcss-sass/issues/175.
 name: Deploy
 
 on:
@@ -24,29 +27,6 @@ jobs:
         with:
           name: webpage
           path: public/*
-
-  # There is an action called `reviewdog/action-stylelint`. However, it requires `package.json` even if a project is not managed by npm.
-  # That is why I install and run stylelint manually.
-  check_css:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Get the npm cache directory
-        id: npm-cache-dir
-        run: echo "::set-output name=dir::$(npm config get cache)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-stylelint
-
-      - name: Install stylelint
-        run: npm install stylelint postcss-sass --location=global
-
-      - name: Run stylelint
-        run: stylelint sass/**/*
 
   check_head_and_body_concatenation:
     runs-on: ubuntu-latest
@@ -116,7 +96,6 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [ build
-           , check_css
            , check_head_and_body_concatenation
            , check_python_file_format
            , check_translations

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,0 @@
-{
-    "customSyntax": "postcss-sass",
-    "rules": {
-        "indentation": 4
-    }
-}


### PR DESCRIPTION
We have to combine `postcss-sass` with `stylelint` to format SASS files,
but `postcss-sass` is no longer maintained.
See https://github.com/AleshaOleg/postcss-sass/issues/175.
