### PR TITLE
fix: restore zola CI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,5 +6,5 @@ build_search_index = false
 title = "備忘録やめた"
 description = "toku-sa-nによる個人ブログ"
 
-[markdown]
-highlight_code = true
+[markdown.highlighting]
+theme = "one-dark-pro"

--- a/config.toml
+++ b/config.toml
@@ -8,3 +8,8 @@ description = "toku-sa-nによる個人ブログ"
 
 [markdown.highlighting]
 theme = "one-dark-pro"
+
+[link_checker]
+skip_prefixes = [
+    "https://www.winehq.org/",
+]


### PR DESCRIPTION
The CI on `main` was failing with Zola 0.22.1 for two separate reasons.

First, the repository still used the removed `highlight_code` markdown setting, which caused both `zola build` and `zola check` to fail while parsing `config.toml`.

After updating that setting, `zola check` still failed in GitHub Actions because WineHQ responds with `403 Forbidden` for the URLs referenced in `content/blog/about_zakuzaku_actors/index.md`.

This PR keeps the fix minimal by:
- migrating the markdown highlighting config to the current Zola format
- skipping only the affected WineHQ URLs in the link checker

The article content and the workflow remain unchanged, and external link checking is still enforced for other URLs.