### PR TITLE
fix: deploy site with GitHub Pages artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,13 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,11 +41,10 @@ jobs:
       - name: Run Autoprefixer
         run: npx postcss public/*.css --use autoprefixer --replace
 
-      - name: Upload as an artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          name: webpage
-          path: public/*
+          path: public/
 
   # There is an action called `reviewdog/action-stylelint`. However, it
   # requires `package.json` even if a project is not managed by npm.  That is
@@ -86,39 +92,23 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     needs: [ build
            , check_css
            , check_python_file_format
            , check_zola
            ]
 
-    if: github.ref == 'refs/heads/main' && github.event_name != 'schedule'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Set the committer information
-        run: |
-          git config --global user.name 'Hiroki Tokunaga'
-          git config --global user.email 'toku-sa-n@users.noreply.github.com'
-
-      - name: Checkout to the `gh-pages` branch
-        run: |
-          git pull
-          git checkout gh-pages
-
-      - name: Clean up the directory
-        run: rm -rf *
-
-      - name: Download the artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: webpage
-
-      - name: Commit
-        run: |
-          git add .
-          git diff-index --quiet HEAD || git commit -m 'Deploy the website'
-
-      - name: Push
-        run: git push
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,15 @@
 - Keep this guide in English; do not translate AGENTS.md.
 
 ## Testing Guidelines
-- No shared test runner is maintained. Keep code samples lightweight and self-contained inside each post.
+- GitHub Actions runs the Zola build, Stylelint, Black, and `zola check` for pushes, pull requests, and the scheduled build.
+- GitHub Actions deploys successful `main` push builds to GitHub Pages using the official Pages artifact workflow.
+- Keep code samples lightweight and self-contained inside each post.
 
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits (e.g., `docs: add repository guidelines`, `feat: add new post`); keep summaries ≈72 chars.
 - PR description: state why the change is needed; omit what/tests. Link issues; add screenshots if the UI changes.
 - Default to Draft PRs; mark Ready for Review after checks pass.
-- Merge gate: `zola check` passes; run `zola build` when deploying.
+- Merge gate: all GitHub Actions checks pass; also run `zola check` and `zola build` locally before pushing.
 - When you change workflows, commands, or style rules, update `AGENTS.md` in the same PR so contributors stay in sync.
 - Keep PRs single-commit; squash locally. Final commit message matches the PR title (Conventional).
 
@@ -38,4 +40,4 @@
 - Do not edit `public/`; always regenerate with `zola build`.
 - Never commit secrets. Only public-safe values belong in `config.toml`.
 - Keep all files under `licenses/` untouched.
-- CI is absent; treat local build and test results as mandatory checks.
+- GitHub Actions owns automated checks and GitHub Pages deployment; treat local build and test results as mandatory pre-push checks.


### PR DESCRIPTION
従来のデプロイは、GitHub Actions から `gh-pages` ブランチへコミットを push する方式でした。ワークフローの `GITHUB_TOKEN` が読み取り専用の場合、この push は GitHub から 403 で拒否されるため、サイトを公開できません。

GitHub Pages 公式の artifact デプロイ方式へ移行し、ビルド成果物を Pages artifact として渡したうえで、全チェックに成功した `main` への push だけを `github-pages` environment へ公開します。通常処理はリポジトリ内容の読み取り、公開処理は Pages 書き込みと OIDC トークン発行だけに権限を限定します。

公開 API とサイト URL に変更はありません。マージ後の次回デプロイから `https://toku-sa-n.github.io/` は同じ Zola サイトを公式 Pages ワークフロー経由で配信します。既存の `gh-pages` ブランチはこの PR では削除しません。

ローカルでは `zola check` と `zola build` が成功しています。
