### PR TITLE
fix: update cache action to Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         id: npm-cache-dir
         run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-stylelint
@@ -59,7 +59,7 @@ jobs:
         id: npm-cache-dir
         run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-stylelint

--- a/.github/workflows/install_zola/action.yml
+++ b/.github/workflows/install_zola/action.yml
@@ -12,7 +12,7 @@ runs:
       run: git clone https://github.com/getzola/zola
       shell: bash
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/bin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - PR description: state why the change is needed; omit what/tests. Link issues; add screenshots if the UI changes.
 - Default to Draft PRs; mark Ready for Review after checks pass.
 - Merge gate: all GitHub Actions checks pass; also run `zola check` and `zola build` locally before pushing.
+- Pin third-party GitHub Actions to full commit SHAs and note the corresponding release in comments.
 - When you change workflows, commands, or style rules, update `AGENTS.md` in the same PR so contributors stay in sync.
 - Keep PRs single-commit; squash locally. Final commit message matches the PR title (Conventional).
 


### PR DESCRIPTION
GitHub Actions の各チェックでは、Node.js 20 を使用する `actions/cache@v4.3.0` が非推奨となり、GitHub 側で Node.js 24 を強制適用する警告が出ていました。現時点ではジョブは成功しているものの、互換処理に依存した状態を残すと将来のランタイム切り替えで失敗する可能性があります。

`actions/cache` を、manifest 自体が Node.js 24 を使用する `v6.1.0` へ更新します。リポジトリの方針に従って完全なコミット SHA で固定し、既存のキャッシュ対象・キー・restore key は変更しません。あわせて、第三者ActionのSHA固定ルールをコントリビューター向けガイドに明記します。

サイト内容、公開URL、GitHub Pagesのデプロイ方式に影響はありません。ローカルでは `zola check`、`zola build`、`git diff --check` が成功しています。
